### PR TITLE
Properties must be sorted

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,11 +192,11 @@ func main() {
 		}
 
 		// Properties
-		for propertyName, propertyValue := range definition.Properties {
+		for _, property := range definition.SortedProperties() {
 			instantiation = append(instantiation, &ast.AssignStmt{
 				Tok: token.ASSIGN,
-				Lhs: []ast.Expr{&ast.Ident{Name: serviceTempVariable + "." + propertyName}},
-				Rhs: []ast.Expr{&ast.Ident{Name: resolveStatement(propertyValue)}},
+				Lhs: []ast.Expr{&ast.Ident{Name: serviceTempVariable + "." + property.Name}},
+				Rhs: []ast.Expr{&ast.Ident{Name: resolveStatement(property.Value)}},
 			})
 		}
 

--- a/property.go
+++ b/property.go
@@ -1,0 +1,5 @@
+package main
+
+type Property struct {
+	Name, Value string
+}

--- a/service.go
+++ b/service.go
@@ -1,5 +1,7 @@
 package main
 
+import "sort"
+
 type Service struct {
 	Type       Type
 	Interface  Type
@@ -41,4 +43,22 @@ func (service *Service) Imports() map[string]string {
 	}
 
 	return imports
+}
+
+func (service *Service) SortedProperties() (sortedProperties []*Property) {
+	var propertyNames []string
+	for propertyName := range service.Properties {
+		propertyNames = append(propertyNames, propertyName)
+	}
+
+	sort.Strings(propertyNames)
+
+	for _, propertyName := range propertyNames {
+		sortedProperties = append(sortedProperties, &Property{
+			Name:  propertyName,
+			Value: service.Properties[propertyName],
+		})
+	}
+
+	return
 }


### PR DESCRIPTION
The "properties" must be sorted so that the generated dingo.go is deterministic. It also makes it a little easier to read.