### PR TITLE
Adding "func" types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ properties:
 
 ### returns
 
-The expression used to instantiate the service. You can provide any Go code
-here, including referencing other services and environment variables.
+The expression used to instantiate the service. You can provide any Go
+expression here, including referencing other services and environment variables.
+
+The `returns` can also return a function, since it is an expression. See `type`
+for an example.
 
 ### scope
 
@@ -142,8 +145,19 @@ name that includes the package name if the type does not belong to this package.
 
 Example
 
-```:
+```yml
 type: '*github.com/go-redis/redis.Options'
+```
+
+The `type` may also be a function. Functions can refer to other services in the
+same embedded way:
+
+```yml
+type: func () bool
+returns: |
+  func () bool {
+    return @{Something}.IsReady()
+  }
 ```
 
 ## Using Services

--- a/dingotest/dingo.go
+++ b/dingotest/dingo.go
@@ -7,19 +7,33 @@ import (
 )
 
 type Container struct {
-	CustomerWelcome	*CustomerWelcome
-	OtherPkg	*go_sub_pkg.Person
-	OtherPkg2	go_sub_pkg.Greeter
-	OtherPkg3	*go_sub_pkg.Person
-	SendEmail	EmailSender
-	SendEmailError	*SendEmail
-	SomeEnv		*string
-	WithEnv1	*SendEmail
-	WithEnv2	*SendEmail
+	AFunc           func(int, int) (bool, bool)
+	CustomerWelcome *CustomerWelcome
+	OtherPkg        *go_sub_pkg.Person
+	OtherPkg2       go_sub_pkg.Greeter
+	OtherPkg3       *go_sub_pkg.Person
+	SendEmail       EmailSender
+	SendEmailError  *SendEmail
+	SomeEnv         *string
+	WithEnv1        *SendEmail
+	WithEnv2        *SendEmail
 }
 
 var DefaultContainer = &Container{}
 
+func (container *Container) GetAFunc() func(int, int) (bool, bool) {
+	if container.AFunc == nil {
+		service := func(a, b int) (c, d bool) {
+			c = (a + b) != 0
+			d = container.GetSomeEnv() != ""
+
+			return
+		}
+
+		container.AFunc = service
+	}
+	return container.AFunc
+}
 func (container *Container) GetCustomerWelcome() *CustomerWelcome {
 	if container.CustomerWelcome == nil {
 		service := NewCustomerWelcome(container.GetSendEmail())

--- a/dingotest/dingo.yml
+++ b/dingotest/dingo.yml
@@ -43,3 +43,13 @@ services:
     type: '*SendEmail'
     returns: NewSendEmail()
     error: panic(err)
+
+  AFunc:
+    type: func (int, int) (bool, bool)
+    returns: |
+      func (a, b int) (c, d bool) {
+        c = (a + b) != 0
+        d = @{SomeEnv} != ""
+
+        return
+      }

--- a/service_test.go
+++ b/service_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 )
 
-var serviceValidationTests = map[string]struct{
+var serviceValidationTests = map[string]struct {
 	service *Service
-	err error
+	err     error
 }{
 	"empty": {
 		service: &Service{},
-		err: nil,
+		err:     nil,
 	},
 	"scope_prototype": {
 		service: &Service{

--- a/type.go
+++ b/type.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -8,15 +9,30 @@ import (
 type Type string
 
 func (ty Type) String() string {
+	if ty.IsFunction() {
+		args, returns := ty.parseFunctionType()
+		switch len(returns) {
+		case 0:
+			return fmt.Sprintf("func (%s)", args)
+
+		case 1:
+			return fmt.Sprintf("func (%s) %s", args, strings.Join(returns, ","))
+
+		default:
+			return fmt.Sprintf("func (%s) (%s)", args,
+				strings.Join(returns, ","))
+		}
+	}
+
 	return string(ty)
 }
 
 func (ty Type) IsPointer() bool {
-	return strings.HasPrefix(string(ty), "*")
+	return strings.HasPrefix(string(ty), "*") || ty.IsFunction()
 }
 
 func (ty Type) PackageName() string {
-	if !strings.Contains(string(ty), ".") {
+	if ty.IsFunction() || !strings.Contains(string(ty), ".") {
 		return ""
 	}
 
@@ -25,6 +41,10 @@ func (ty Type) PackageName() string {
 }
 
 func (ty Type) UnversionedPackageName() string {
+	if ty.IsFunction() {
+		return ""
+	}
+
 	packageName := strings.Split(ty.PackageName(), "/")
 	if regexp.MustCompile(`^v\d+$`).MatchString(packageName[len(packageName)-1]) {
 		packageName = packageName[:len(packageName)-1]
@@ -34,6 +54,10 @@ func (ty Type) UnversionedPackageName() string {
 }
 
 func (ty Type) LocalPackageName() string {
+	if ty.IsFunction() {
+		return ""
+	}
+
 	pkgNameParts := strings.Split(ty.UnversionedPackageName(), "/")
 	lastPart := pkgNameParts[len(pkgNameParts)-1]
 
@@ -41,18 +65,30 @@ func (ty Type) LocalPackageName() string {
 }
 
 func (ty Type) EntityName() string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
 	parts := strings.Split(string(ty), ".")
 
 	return strings.TrimLeft(parts[len(parts)-1], "*")
 }
 
 func (ty Type) LocalEntityName() string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
 	name := ty.LocalPackageName() + "." + ty.EntityName()
 
 	return strings.TrimLeft(name, ".")
 }
 
 func (ty Type) LocalEntityType() string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
 	name := ty.LocalEntityName()
 	if ty.IsPointer() {
 		name = "*" + name
@@ -62,6 +98,10 @@ func (ty Type) LocalEntityType() string {
 }
 
 func (ty Type) CreateLocalEntityType() string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
 	name := ty.LocalEntityName()
 	if ty.IsPointer() {
 		name = "&" + name
@@ -71,10 +111,44 @@ func (ty Type) CreateLocalEntityType() string {
 }
 
 func (ty Type) LocalEntityPointerType() string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
 	name := ty.LocalEntityName()
 	if !strings.HasPrefix(name, "*") {
 		name = "*" + name
 	}
 
 	return name
+}
+
+// IsFunction returns true if the type represents a function pointer, like
+// "func ()".
+func (ty Type) IsFunction() bool {
+	return strings.HasPrefix(string(ty), "func")
+}
+
+var (
+	functionRegexp1 = regexp.MustCompile(`func\s*\((.*?)\)\s*\((.*)\)`)
+	functionRegexp2 = regexp.MustCompile(`func\s*\((.*?)\)\s*(.*)`)
+)
+
+func (ty Type) splitArgs(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	return strings.Split(s, ",")
+}
+
+func (ty Type) parseFunctionType() (string, []string) {
+	matches := functionRegexp1.FindStringSubmatch(string(ty))
+	if len(matches) > 0 {
+		return matches[1], ty.splitArgs(matches[2])
+	}
+
+	matches = functionRegexp2.FindStringSubmatch(string(ty))
+
+	return matches[1], ty.splitArgs(matches[2])
 }

--- a/type_test.go
+++ b/type_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 var typeTests = map[Type]struct {
+	String                 string
 	IsPointer              bool
 	PackageName            string
 	LocalPackageName       string
@@ -15,8 +16,10 @@ var typeTests = map[Type]struct {
 	CreateLocalEntityType  string
 	LocalEntityPointerType string
 	UnversionedPackageName string
+	IsFunction             bool
 }{
 	"Person": {
+		String:                 "Person",
 		IsPointer:              false,
 		PackageName:            "",
 		LocalPackageName:       "",
@@ -26,8 +29,10 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "Person",
 		LocalEntityPointerType: "*Person",
 		UnversionedPackageName: "",
+		IsFunction:             false,
 	},
 	"*Person": {
+		String:                 "*Person",
 		IsPointer:              true,
 		PackageName:            "",
 		LocalPackageName:       "",
@@ -37,8 +42,10 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "&Person",
 		LocalEntityPointerType: "*Person",
 		UnversionedPackageName: "",
+		IsFunction:             false,
 	},
 	"github.com/elliotchance/dingo/dingotest/go-sub-pkg.Person": {
+		String:                 "github.com/elliotchance/dingo/dingotest/go-sub-pkg.Person",
 		IsPointer:              false,
 		PackageName:            "github.com/elliotchance/dingo/dingotest/go-sub-pkg",
 		LocalPackageName:       "go_sub_pkg",
@@ -48,8 +55,10 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "go_sub_pkg.Person",
 		LocalEntityPointerType: "*go_sub_pkg.Person",
 		UnversionedPackageName: "github.com/elliotchance/dingo/dingotest/go-sub-pkg",
+		IsFunction:             false,
 	},
 	"*github.com/elliotchance/dingo/dingotest/go-sub-pkg.Person": {
+		String:                 "*github.com/elliotchance/dingo/dingotest/go-sub-pkg.Person",
 		IsPointer:              true,
 		PackageName:            "github.com/elliotchance/dingo/dingotest/go-sub-pkg",
 		LocalPackageName:       "go_sub_pkg",
@@ -59,8 +68,10 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "&go_sub_pkg.Person",
 		LocalEntityPointerType: "*go_sub_pkg.Person",
 		UnversionedPackageName: "github.com/elliotchance/dingo/dingotest/go-sub-pkg",
+		IsFunction:             false,
 	},
 	"github.com/kounta/luigi/v7.Logger": {
+		String:                 "github.com/kounta/luigi/v7.Logger",
 		IsPointer:              false,
 		PackageName:            "github.com/kounta/luigi/v7",
 		LocalPackageName:       "luigi",
@@ -70,8 +81,10 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "luigi.Logger",
 		LocalEntityPointerType: "*luigi.Logger",
 		UnversionedPackageName: "github.com/kounta/luigi",
+		IsFunction:             false,
 	},
 	"*github.com/kounta/luigi/v7.SimpleLogger": {
+		String:                 "*github.com/kounta/luigi/v7.SimpleLogger",
 		IsPointer:              true,
 		PackageName:            "github.com/kounta/luigi/v7",
 		LocalPackageName:       "luigi",
@@ -81,13 +94,53 @@ var typeTests = map[Type]struct {
 		CreateLocalEntityType:  "&luigi.SimpleLogger",
 		LocalEntityPointerType: "*luigi.SimpleLogger",
 		UnversionedPackageName: "github.com/kounta/luigi",
+		IsFunction:             false,
+	},
+	"func()": {
+		String:                 "func ()",
+		IsPointer:              true,
+		PackageName:            "",
+		LocalPackageName:       "",
+		EntityName:             "func ()",
+		LocalEntityName:        "func ()",
+		LocalEntityType:        "func ()",
+		CreateLocalEntityType:  "func ()",
+		LocalEntityPointerType: "func ()",
+		UnversionedPackageName: "",
+		IsFunction:             true,
+	},
+	"func  (a, b int) (*foo.Bar)": {
+		String:                 "func (a, b int) *foo.Bar",
+		IsPointer:              true,
+		PackageName:            "",
+		LocalPackageName:       "",
+		EntityName:             "func (a, b int) *foo.Bar",
+		LocalEntityName:        "func (a, b int) *foo.Bar",
+		LocalEntityType:        "func (a, b int) *foo.Bar",
+		CreateLocalEntityType:  "func (a, b int) *foo.Bar",
+		LocalEntityPointerType: "func (a, b int) *foo.Bar",
+		UnversionedPackageName: "",
+		IsFunction:             true,
+	},
+	"func(s string) (float64, bool)": {
+		String:                 "func (s string) (float64, bool)",
+		IsPointer:              true,
+		PackageName:            "",
+		LocalPackageName:       "",
+		EntityName:             "func (s string) (float64, bool)",
+		LocalEntityName:        "func (s string) (float64, bool)",
+		LocalEntityType:        "func (s string) (float64, bool)",
+		CreateLocalEntityType:  "func (s string) (float64, bool)",
+		LocalEntityPointerType: "func (s string) (float64, bool)",
+		UnversionedPackageName: "",
+		IsFunction:             true,
 	},
 }
 
 func TestType_String(t *testing.T) {
 	for ty := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, string(ty), ty.String())
+			assert.Equal(t, ty.String(), ty.String())
 		})
 	}
 }
@@ -160,6 +213,14 @@ func TestType_UnversionedPackageName(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
 			assert.Equal(t, test.UnversionedPackageName, ty.UnversionedPackageName())
+		})
+	}
+}
+
+func TestType_IsFunction(t *testing.T) {
+	for ty, test := range typeTests {
+		t.Run(string(ty), func(t *testing.T) {
+			assert.Equal(t, test.IsFunction, ty.IsFunction())
 		})
 	}
 }


### PR DESCRIPTION
The `type` now allows functions, such as "func () bool". The `returns` can be used to return such a function and the contents can contain references to other services like all other Go expressions.