### PR TITLE
Handling situation when there is no such service which we can quote on

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/elliotchance/pie/pie"
 	"go/ast"
-	"golang.org/x/tools/go/ast/astutil"
 	"regexp"
 	"strings"
+
+	"github.com/elliotchance/pie/pie"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 type Expression string
@@ -48,6 +49,10 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 
 			if strings.Contains(i[1], "(") {
 				return fmt.Sprintf("container.Get%s", i[1])
+			}
+
+			if _, existsService := services[i[1]]; !existsService {
+				panic(fmt.Errorf("Cannot cite to %s service, please ensure you have this one accessible", i[1]))
 			}
 
 			if _, ok := services[i[1]].ContainerFieldType(services).(*ast.FuncType); ok {

--- a/expression.go
+++ b/expression.go
@@ -52,7 +52,7 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 			}
 
 			if _, existsService := services[i[1]]; !existsService {
-				panic(fmt.Errorf("Cannot cite to %s service, please ensure you have this one accessible", i[1]))
+				panic(fmt.Sprintf("service does not exist: %s", i[1]))
 			}
 
 			if _, ok := services[i[1]].ContainerFieldType(services).(*ast.FuncType); ok {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/printer"
 	"log"
 	"os"
@@ -28,6 +29,12 @@ func main() {
 	dingoYMLPath := "dingo.yml"
 	outputFile := "dingo.go"
 
+	defer func() {
+		if recoverErr := recover(); recoverErr != nil {
+			fmt.Printf("Error => %v\n", checkError(recoverErr))
+		}
+	}()
+
 	file, err := ParseYAMLFile(dingoYMLPath, outputFile)
 	if err != nil {
 		log.Fatalln(err)
@@ -42,4 +49,16 @@ func main() {
 	if err != nil {
 		log.Fatalln("writer:", err)
 	}
+}
+
+func checkError(i interface{}) error {
+	if i != nil {
+		if err, isError := i.(error); isError {
+			return  err
+		}
+
+		return fmt.Errorf("The programme has been just crushed with %v", i)
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"go/printer"
 	"log"
 	"os"
@@ -29,12 +28,6 @@ func main() {
 	dingoYMLPath := "dingo.yml"
 	outputFile := "dingo.go"
 
-	defer func() {
-		if recoverErr := recover(); recoverErr != nil {
-			fmt.Printf("Error => %v\n", checkError(recoverErr))
-		}
-	}()
-
 	file, err := ParseYAMLFile(dingoYMLPath, outputFile)
 	if err != nil {
 		log.Fatalln(err)
@@ -49,16 +42,4 @@ func main() {
 	if err != nil {
 		log.Fatalln("writer:", err)
 	}
-}
-
-func checkError(i interface{}) error {
-	if i != nil {
-		if err, isError := i.(error); isError {
-			return  err
-		}
-
-		return fmt.Errorf("The programme has been just crushed with %v", i)
-	}
-
-	return nil
 }


### PR DESCRIPTION
Hello @elliotchance it closes #13 

I am not confident that is the best solution or not.
I would like only remark that I have not found any better one then this.

We just panic with some error and in main we process it.

In my opinion, it rather be provided err as `Err types` than `fmt.Erorrf()` as well, but is slightly another issue.

#### Changes that came up this of late bring this out

### dingo.yml

```
services:
  AWSBucket:
    type: 'int'
    returns: '@{S3Client}'
```

### output
```
Error => Cannot cite to S3Client service, please ensure you have this one accessible
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/dingo/15)
<!-- Reviewable:end -->
