### PR TITLE
Handle packages with duplicate names (resolve #21)

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -21,7 +21,7 @@ func (args Arguments) Names() (names []string) {
 func (args Arguments) GoArguments() (ss []string) {
 	for _, argName := range args.Names() {
 		ss = append(ss, fmt.Sprintf("%s %s", argName,
-			args[argName].LocalEntityType()))
+			args[argName].LocalEntityType(nil)))
 	}
 
 	return

--- a/dingotest/dingo.go
+++ b/dingotest/dingo.go
@@ -10,29 +10,37 @@ import (
 )
 
 type Container struct {
-	AFunc            func(int, int) (bool, bool)
-	Clock            clockwork.Clock
-	CustomerWelcome  *CustomerWelcome
-	DependsOnTime    func(ParsedTime time.Time) time.Time
-	HTTPSignerClient *HTTPSignerClient
-	Now              func() time.Time
-	OtherPkg         *go_sub_pkg.Person
-	OtherPkg2        go_sub_pkg.Greeter
-	OtherPkg3        *go_sub_pkg.Person
-	ParsedTime       func(value string) time.Time
-	SendEmail        EmailSender
-	SendEmailError   *SendEmail
-	Signer           func(req *http.Request) *Signer
-	SomeEnv          *string
-	WhatsTheTime     *WhatsTheTime
-	WithEnv1         *SendEmail
-	WithEnv2         *SendEmail
+	AFunc				func (int, int) (bool, bool)
+	Clock				clockwork.Clock
+	CustomerWelcome			*CustomerWelcome
+	CustomerWelcomePrototype	func(SendEmail EmailSender, appid string) *CustomerWelcome
+	CustomerWelcomePrototype2	func(SendEmail EmailSender, config string) *CustomerWelcome
+	DependsOnTime			func(ParsedTime time.Time) time.Time
+	HTTPSignerClient		*HTTPSignerClient
+	Now				func() time.Time
+	OtherPkg			*go_sub_pkg.Person
+	OtherPkg2			go_sub_pkg.Greeter
+	OtherPkg3			*go_sub_pkg.Person
+	ParsedTime			func(value string) time.Time
+	SendEmail			EmailSender
+	SendEmailError			*SendEmail
+	Signer				func(req *http.Request) *Signer
+	SomeEnv				*string
+	WhatsTheTime			*WhatsTheTime
+	WithEnv1			*SendEmail
+	WithEnv2			*SendEmail
 }
 
 var DefaultContainer = NewContainer()
 
 func NewContainer() *Container {
-	return &Container{DependsOnTime: func(ParsedTime time.Time) time.Time {
+	return &Container{CustomerWelcomePrototype: func(SendEmail EmailSender, appid string) *CustomerWelcome {
+		service := NewCustomerWelcome(SendEmail)
+		return service
+	}, CustomerWelcomePrototype2: func(SendEmail EmailSender, config string) *CustomerWelcome {
+		service := NewCustomerWelcome(SendEmail)
+		return service
+	}, DependsOnTime: func(ParsedTime time.Time) time.Time {
 		service := ParsedTime
 		return service
 	}, Now: func() time.Time {
@@ -49,14 +57,14 @@ func NewContainer() *Container {
 		return service
 	}}
 }
-func (container *Container) GetAFunc() func(int, int) (bool, bool) {
+func (container *Container) GetAFunc() func (int, int) (bool, bool) {
 	if container.AFunc == nil {
-		service := func(a, b int) (c, d bool) {
-			c = (a + b) != 0
-			d = container.GetSomeEnv() != ""
+		service := func (a, b int) (c, d bool) {
+  c = (a + b) != 0
+  d = container.GetSomeEnv() != ""
 
-			return
-		}
+  return
+}
 
 		container.AFunc = service
 	}
@@ -75,6 +83,12 @@ func (container *Container) GetCustomerWelcome() *CustomerWelcome {
 		container.CustomerWelcome = service
 	}
 	return container.CustomerWelcome
+}
+func (container *Container) GetCustomerWelcomePrototype(appid string) *CustomerWelcome {
+	return container.CustomerWelcomePrototype(container.GetSendEmail(), appid)
+}
+func (container *Container) GetCustomerWelcomePrototype2(config string) *CustomerWelcome {
+	return container.CustomerWelcomePrototype2(container.GetSendEmail(), config)
 }
 func (container *Container) GetDependsOnTime() time.Time {
 	return container.DependsOnTime(container.GetParsedTime("13 Jan 06 15:04 MST"))

--- a/expression.go
+++ b/expression.go
@@ -55,7 +55,7 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 				panic(fmt.Sprintf("service does not exist: %s", i[1]))
 			}
 
-			if _, ok := services[i[1]].ContainerFieldType(services).(*ast.FuncType); ok {
+			if _, ok := services[i[1]].ContainerFieldType(services, nil).(*ast.FuncType); ok {
 				return fmt.Sprintf("container.%s", i[1])
 			}
 

--- a/expression.go
+++ b/expression.go
@@ -68,31 +68,6 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 	return stmt
 }
 
-// replacePackagePrefixes replaces unqualified package names with their resolved aliases
-func (e Expression) replacePackagePrefixes(stmt string, importMap ImportMap) string {
-	// Build a reverse map from short names to resolved names
-	shortToResolved := make(map[string]string)
-
-	for fullPath, resolvedName := range importMap {
-		parts := strings.Split(fullPath, "/")
-		if len(parts) > 0 {
-			defaultShortName := parts[len(parts)-1]
-			defaultShortName = strings.ReplaceAll(defaultShortName, "-", "_")
-
-			if defaultShortName != resolvedName {
-				shortToResolved[defaultShortName] = resolvedName
-			}
-		}
-	}
-
-	for shortName, resolvedName := range shortToResolved {
-		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(shortName) + `\.`)
-		stmt = pattern.ReplaceAllString(stmt, resolvedName+".")
-	}
-
-	return stmt
-}
-
 // replacePackagePrefixesWithContext replaces package prefixes with awareness of the service's context
 func (e Expression) replacePackagePrefixesWithContext(stmt string, serviceType Type, importMap ImportMap) string {
 	if serviceType.PackageName() == "" {

--- a/expression.go
+++ b/expression.go
@@ -62,5 +62,65 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 			return fmt.Sprintf("container.Get%s()", i[1])
 		})
 
+	// Note: Package prefix replacement is now done with context in astFunctionBody
+	// to avoid replacing the wrong package when there are conflicts
+
+	return stmt
+}
+
+// replacePackagePrefixes replaces unqualified package names with their resolved aliases
+// contextPackage is the full package path that this expression belongs to (from the service's type)
+func (e Expression) replacePackagePrefixes(stmt string, importMap ImportMap) string {
+	// Build a reverse map from short names to resolved names
+	shortToResolved := make(map[string]string)
+
+	for fullPath, resolvedName := range importMap {
+		// Extract the default short name from the full path
+		parts := strings.Split(fullPath, "/")
+		if len(parts) > 0 {
+			defaultShortName := parts[len(parts)-1]
+			defaultShortName = strings.ReplaceAll(defaultShortName, "-", "_")
+
+			// Only map if the resolved name is different from the default
+			if defaultShortName != resolvedName {
+				shortToResolved[defaultShortName] = resolvedName
+			}
+		}
+	}
+
+	// Replace package prefixes in the statement
+	// Match pattern: packageName.Identifier
+	for shortName, resolvedName := range shortToResolved {
+		// Use word boundaries to avoid partial matches
+		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(shortName) + `\.`)
+		stmt = pattern.ReplaceAllString(stmt, resolvedName+".")
+	}
+
+	return stmt
+}
+
+// replacePackagePrefixesWithContext replaces package prefixes with awareness of the service's context
+func (e Expression) replacePackagePrefixesWithContext(stmt string, serviceType Type, importMap ImportMap) string {
+	if serviceType.PackageName() == "" {
+		return stmt
+	}
+
+	// Get the package path and default short name for this service's type
+	servicePkgPath := serviceType.PackageName()
+	parts := strings.Split(servicePkgPath, "/")
+	if len(parts) == 0 {
+		return stmt
+	}
+
+	defaultShortName := parts[len(parts)-1]
+	defaultShortName = strings.ReplaceAll(defaultShortName, "-", "_")
+
+	// Get the resolved name for this service's package
+	if resolvedName, ok := importMap[servicePkgPath]; ok && resolvedName != defaultShortName {
+		// Replace the default short name with the resolved name in this statement
+		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(defaultShortName) + `\.`)
+		stmt = pattern.ReplaceAllString(stmt, resolvedName+".")
+	}
+
 	return stmt
 }

--- a/expression.go
+++ b/expression.go
@@ -69,29 +69,23 @@ func (e Expression) performSubstitutions(file *File, services Services, fromArgs
 }
 
 // replacePackagePrefixes replaces unqualified package names with their resolved aliases
-// contextPackage is the full package path that this expression belongs to (from the service's type)
 func (e Expression) replacePackagePrefixes(stmt string, importMap ImportMap) string {
 	// Build a reverse map from short names to resolved names
 	shortToResolved := make(map[string]string)
 
 	for fullPath, resolvedName := range importMap {
-		// Extract the default short name from the full path
 		parts := strings.Split(fullPath, "/")
 		if len(parts) > 0 {
 			defaultShortName := parts[len(parts)-1]
 			defaultShortName = strings.ReplaceAll(defaultShortName, "-", "_")
 
-			// Only map if the resolved name is different from the default
 			if defaultShortName != resolvedName {
 				shortToResolved[defaultShortName] = resolvedName
 			}
 		}
 	}
 
-	// Replace package prefixes in the statement
-	// Match pattern: packageName.Identifier
 	for shortName, resolvedName := range shortToResolved {
-		// Use word boundaries to avoid partial matches
 		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(shortName) + `\.`)
 		stmt = pattern.ReplaceAllString(stmt, resolvedName+".")
 	}
@@ -105,7 +99,6 @@ func (e Expression) replacePackagePrefixesWithContext(stmt string, serviceType T
 		return stmt
 	}
 
-	// Get the package path and default short name for this service's type
 	servicePkgPath := serviceType.PackageName()
 	parts := strings.Split(servicePkgPath, "/")
 	if len(parts) == 0 {
@@ -115,9 +108,7 @@ func (e Expression) replacePackagePrefixesWithContext(stmt string, serviceType T
 	defaultShortName := parts[len(parts)-1]
 	defaultShortName = strings.ReplaceAll(defaultShortName, "-", "_")
 
-	// Get the resolved name for this service's package
 	if resolvedName, ok := importMap[servicePkgPath]; ok && resolvedName != defaultShortName {
-		// Replace the default short name with the resolved name in this statement
 		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(defaultShortName) + `\.`)
 		stmt = pattern.ReplaceAllString(stmt, resolvedName+".")
 	}

--- a/file.go
+++ b/file.go
@@ -47,9 +47,9 @@ func GenerateContainer(all *File, packageName string, outputFile string) (*File,
 	all.importMap = CollectAndResolveImports(all.Services)
 
 	all.file.Decls = append(all.file.Decls,
-		all.Services.astContainerStructWithMap(all.importMap),
+		all.Services.astContainerStruct(all.importMap),
 		all.Services.astDefaultContainer(),
-		all.astNewContainerFuncWithMap())
+		all.astNewContainerFunc())
 
 	for _, serviceName := range all.Services.ServiceNames() {
 		definition := all.Services[serviceName]
@@ -83,7 +83,7 @@ func GenerateContainer(all *File, packageName string, outputFile string) (*File,
 			},
 			Type: &ast.FuncType{
 				Params:  definition.astArguments(),
-				Results: newFieldList(definition.InterfaceOrLocalEntityTypeWithMap(all.Services, false, all.importMap)),
+				Results: newFieldList(definition.InterfaceOrLocalEntityType(all.Services, false, all.importMap)),
 			},
 			Body: definition.astFunctionBody(all, all.Services, serviceName, serviceName),
 		})
@@ -136,23 +136,7 @@ func (file *File) astNewContainerFunc() *ast.FuncDecl {
 	for _, serviceName := range file.Services.ServicesWithScope(ScopePrototype).ServiceNames() {
 		service := file.Services[serviceName]
 		fields[serviceName] = &ast.FuncLit{
-			Type: service.astFunctionPrototype(file.Services),
-			Body: service.astFunctionBody(file, file.Services, "", serviceName),
-		}
-	}
-
-	return newFunc("NewContainer", nil, []string{"*Container"}, newBlock(
-		newReturn(newCompositeLit("&Container", fields)),
-	))
-}
-
-func (file *File) astNewContainerFuncWithMap() *ast.FuncDecl {
-	fields := make(map[string]ast.Expr)
-
-	for _, serviceName := range file.Services.ServicesWithScope(ScopePrototype).ServiceNames() {
-		service := file.Services[serviceName]
-		fields[serviceName] = &ast.FuncLit{
-			Type: service.astFunctionPrototypeWithMap(file.Services, file.importMap),
+			Type: service.astFunctionPrototype(file.Services, file.importMap),
 			Body: service.astFunctionBody(file, file.Services, "", serviceName),
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -13,10 +13,11 @@ import (
 )
 
 type File struct {
-	Package  string
-	Services Services
-	fset     *token.FileSet
-	file     *ast.File
+	Package   string
+	Services  Services
+	fset      *token.FileSet
+	file      *ast.File
+	importMap ImportMap
 }
 
 func ParseYAMLFile(filepath string) (*File, error) {
@@ -42,17 +43,30 @@ func GenerateContainer(all *File, packageName string, outputFile string) (*File,
 		return nil, err
 	}
 
+	// Collect and resolve all imports to handle duplicate package names
+	all.importMap = CollectAndResolveImports(all.Services)
+
 	all.file.Decls = append(all.file.Decls,
-		all.Services.astContainerStruct(),
+		all.Services.astContainerStructWithMap(all.importMap),
 		all.Services.astDefaultContainer(),
-		all.astNewContainerFunc())
+		all.astNewContainerFuncWithMap())
 
 	for _, serviceName := range all.Services.ServiceNames() {
 		definition := all.Services[serviceName]
 
-		// Add imports for type, interface and explicit imports.
-		for packageName, shortName := range definition.Imports() {
-			astutil.AddNamedImport(all.fset, all.file, shortName, packageName)
+		// Add imports using resolved names
+		for packagePath, _ := range definition.Imports() {
+			if packagePath == "" {
+				continue
+			}
+
+			// Get the resolved short name from the import map
+			shortName := ""
+			if resolvedName, ok := all.importMap[packagePath]; ok {
+				shortName = resolvedName
+			}
+
+			astutil.AddNamedImport(all.fset, all.file, shortName, packagePath)
 		}
 
 		all.file.Decls = append(all.file.Decls, &ast.FuncDecl{
@@ -69,7 +83,7 @@ func GenerateContainer(all *File, packageName string, outputFile string) (*File,
 			},
 			Type: &ast.FuncType{
 				Params:  definition.astArguments(),
-				Results: newFieldList(definition.InterfaceOrLocalEntityType(all.Services, false)),
+				Results: newFieldList(definition.InterfaceOrLocalEntityTypeWithMap(all.Services, false, all.importMap)),
 			},
 			Body: definition.astFunctionBody(all, all.Services, serviceName, serviceName),
 		})
@@ -123,6 +137,22 @@ func (file *File) astNewContainerFunc() *ast.FuncDecl {
 		service := file.Services[serviceName]
 		fields[serviceName] = &ast.FuncLit{
 			Type: service.astFunctionPrototype(file.Services),
+			Body: service.astFunctionBody(file, file.Services, "", serviceName),
+		}
+	}
+
+	return newFunc("NewContainer", nil, []string{"*Container"}, newBlock(
+		newReturn(newCompositeLit("&Container", fields)),
+	))
+}
+
+func (file *File) astNewContainerFuncWithMap() *ast.FuncDecl {
+	fields := make(map[string]ast.Expr)
+
+	for _, serviceName := range file.Services.ServicesWithScope(ScopePrototype).ServiceNames() {
+		service := file.Services[serviceName]
+		fields[serviceName] = &ast.FuncLit{
+			Type: service.astFunctionPrototypeWithMap(file.Services, file.importMap),
 			Body: service.astFunctionBody(file, file.Services, "", serviceName),
 		}
 	}

--- a/imports.go
+++ b/imports.go
@@ -24,7 +24,7 @@ func CollectAndResolveImports(services Services) ImportMap {
 			// Use default short name if not specified
 			if shortName == "" {
 				ty := Type(packagePath)
-				shortName = ty.LocalPackageName()
+				shortName = ty.LocalPackageName(nil)
 			}
 
 			importsByShortName[shortName] = append(importsByShortName[shortName], packagePath)

--- a/imports.go
+++ b/imports.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"strings"
+)
+
+// ImportMap stores the mapping from full package paths to their resolved short names
+type ImportMap map[string]string
+
+// CollectAndResolveImports gathers all imports from services and resolves conflicts
+func CollectAndResolveImports(services Services) ImportMap {
+	// First pass: collect all imports with their desired short names
+	importsByShortName := make(map[string][]string) // shortName -> []fullPackagePath
+
+	for _, serviceName := range services.ServiceNames() {
+		definition := services[serviceName]
+		imports := definition.Imports()
+
+		for packagePath, shortName := range imports {
+			if packagePath == "" {
+				continue
+			}
+
+			// Use default short name if not specified
+			if shortName == "" {
+				ty := Type(packagePath)
+				shortName = ty.LocalPackageName()
+			}
+
+			importsByShortName[shortName] = append(importsByShortName[shortName], packagePath)
+		}
+	}
+
+	// Second pass: resolve conflicts
+	resolved := make(ImportMap)
+
+	for shortName, packagePaths := range importsByShortName {
+		// Remove duplicates
+		uniquePaths := make(map[string]bool)
+		var paths []string
+		for _, path := range packagePaths {
+			if !uniquePaths[path] {
+				uniquePaths[path] = true
+				paths = append(paths, path)
+			}
+		}
+
+		if len(paths) == 1 {
+			// No conflict, use the original short name
+			resolved[paths[0]] = shortName
+		} else {
+			// Conflict detected, resolve by adding more path segments
+			resolved = resolveConflict(paths, shortName, resolved)
+		}
+	}
+
+	return resolved
+}
+
+// resolveConflict generates unique names for conflicting packages
+func resolveConflict(packagePaths []string, baseShortName string, resolved ImportMap) ImportMap {
+	// Try to find a unique prefix for each conflicting package
+	for _, path := range packagePaths {
+		uniqueName := generateUniqueName(path, baseShortName, packagePaths)
+		resolved[path] = uniqueName
+	}
+
+	return resolved
+}
+
+// generateUniqueName creates a unique package name by incorporating parent path segments
+func generateUniqueName(packagePath string, baseShortName string, allPaths []string) string {
+	parts := strings.Split(packagePath, "/")
+	if len(parts) == 0 {
+		return baseShortName
+	}
+
+	// Start from the parent directory and work backwards
+	for i := len(parts) - 2; i >= 0; i-- {
+		// Build name from current parent + base name
+		parentPart := sanitizePackageName(parts[i])
+		candidateName := parentPart + "_" + baseShortName
+
+		// Check if this name is unique among all conflicting paths
+		if isUniqueAmong(candidateName, packagePath, allPaths) {
+			return candidateName
+		}
+
+		// If still not unique, try adding more parent segments
+		if i > 0 {
+			grandParent := sanitizePackageName(parts[i-1])
+			candidateName = grandParent + "_" + parentPart + "_" + baseShortName
+			if isUniqueAmong(candidateName, packagePath, allPaths) {
+				return candidateName
+			}
+		}
+	}
+
+	// Fallback: use sanitized full path
+	return sanitizePackageName(strings.ReplaceAll(packagePath, "/", "_"))
+}
+
+// isUniqueAmong checks if the candidate name would be unique for this package path
+func isUniqueAmong(candidateName string, targetPath string, allPaths []string) bool {
+	for _, path := range allPaths {
+		if path == targetPath {
+			continue
+		}
+
+		// Check if another path would also generate the same candidate name
+		parts := strings.Split(path, "/")
+		if len(parts) == 0 {
+			continue
+		}
+
+		// Simple check: if the candidate contains a parent dir from target
+		// it shouldn't match other paths with different parents
+		targetParts := strings.Split(targetPath, "/")
+		if len(targetParts) < 2 {
+			continue
+		}
+
+		// Extract the distinguishing part
+		targetParent := targetParts[len(targetParts)-2]
+		pathParent := ""
+		if len(parts) >= 2 {
+			pathParent = parts[len(parts)-2]
+		}
+
+		// If parents are different, we're good
+		if targetParent != pathParent && strings.Contains(candidateName, sanitizePackageName(targetParent)) {
+			continue
+		}
+
+		// Parents are the same, so this name wouldn't be unique
+		if targetParent == pathParent {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sanitizePackageName converts a path segment into a valid Go identifier
+func sanitizePackageName(name string) string {
+	// Replace hyphens with underscores
+	name = strings.ReplaceAll(name, "-", "_")
+	// Remove any other invalid characters
+	name = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, name)
+	return name
+}

--- a/imports.go
+++ b/imports.go
@@ -59,7 +59,6 @@ func CollectAndResolveImports(services Services) ImportMap {
 
 // resolveConflict generates unique names for conflicting packages
 func resolveConflict(packagePaths []string, baseShortName string, resolved ImportMap) ImportMap {
-	// Try to find a unique prefix for each conflicting package
 	for _, path := range packagePaths {
 		uniqueName := generateUniqueName(path, baseShortName, packagePaths)
 		resolved[path] = uniqueName
@@ -75,18 +74,14 @@ func generateUniqueName(packagePath string, baseShortName string, allPaths []str
 		return baseShortName
 	}
 
-	// Start from the parent directory and work backwards
 	for i := len(parts) - 2; i >= 0; i-- {
-		// Build name from current parent + base name
 		parentPart := sanitizePackageName(parts[i])
 		candidateName := parentPart + "_" + baseShortName
 
-		// Check if this name is unique among all conflicting paths
 		if isUniqueAmong(candidateName, packagePath, allPaths) {
 			return candidateName
 		}
 
-		// If still not unique, try adding more parent segments
 		if i > 0 {
 			grandParent := sanitizePackageName(parts[i-1])
 			candidateName = grandParent + "_" + parentPart + "_" + baseShortName
@@ -107,32 +102,26 @@ func isUniqueAmong(candidateName string, targetPath string, allPaths []string) b
 			continue
 		}
 
-		// Check if another path would also generate the same candidate name
 		parts := strings.Split(path, "/")
 		if len(parts) == 0 {
 			continue
 		}
 
-		// Simple check: if the candidate contains a parent dir from target
-		// it shouldn't match other paths with different parents
 		targetParts := strings.Split(targetPath, "/")
 		if len(targetParts) < 2 {
 			continue
 		}
 
-		// Extract the distinguishing part
 		targetParent := targetParts[len(targetParts)-2]
 		pathParent := ""
 		if len(parts) >= 2 {
 			pathParent = parts[len(parts)-2]
 		}
 
-		// If parents are different, we're good
 		if targetParent != pathParent && strings.Contains(candidateName, sanitizePackageName(targetParent)) {
 			continue
 		}
 
-		// Parents are the same, so this name wouldn't be unique
 		if targetParent == pathParent {
 			return false
 		}
@@ -143,9 +132,7 @@ func isUniqueAmong(candidateName string, targetPath string, allPaths []string) b
 
 // sanitizePackageName converts a path segment into a valid Go identifier
 func sanitizePackageName(name string) string {
-	// Replace hyphens with underscores
 	name = strings.ReplaceAll(name, "-", "_")
-	// Remove any other invalid characters
 	name = strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
 			return r

--- a/imports_test.go
+++ b/imports_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectAndResolveImports_NoConflicts(t *testing.T) {
+	services := Services{
+		"Service1": &Service{
+			Type: "app/foo.Foo",
+		},
+		"Service2": &Service{
+			Type: "app/bar.Bar",
+		},
+	}
+
+	importMap := CollectAndResolveImports(services)
+
+	assert.Equal(t, "foo", importMap["app/foo"])
+	assert.Equal(t, "bar", importMap["app/bar"])
+}
+
+func TestCollectAndResolveImports_WithConflicts(t *testing.T) {
+	services := Services{
+		"HttpClient": &Service{
+			Type: "app/http/clients.Client",
+		},
+		"GrpcClient": &Service{
+			Type: "app/grpc/clients.Client",
+		},
+	}
+
+	importMap := CollectAndResolveImports(services)
+
+	// Both should have resolved names that are different
+	httpName := importMap["app/http/clients"]
+	grpcName := importMap["app/grpc/clients"]
+
+	assert.NotEqual(t, httpName, grpcName, "Resolved names should be different")
+	assert.NotEmpty(t, httpName)
+	assert.NotEmpty(t, grpcName)
+
+	// The names should contain distinguishing information
+	assert.Contains(t, httpName, "http")
+	assert.Contains(t, grpcName, "grpc")
+}
+
+func TestCollectAndResolveImports_MultipleConflicts(t *testing.T) {
+	services := Services{
+		"Service1": &Service{
+			Type: "github.com/org1/utils.Helper",
+		},
+		"Service2": &Service{
+			Type: "github.com/org2/utils.Helper",
+		},
+		"Service3": &Service{
+			Type: "github.com/org3/utils.Helper",
+		},
+	}
+
+	importMap := CollectAndResolveImports(services)
+
+	// All three should have different resolved names
+	name1 := importMap["github.com/org1/utils"]
+	name2 := importMap["github.com/org2/utils"]
+	name3 := importMap["github.com/org3/utils"]
+
+	assert.NotEqual(t, name1, name2)
+	assert.NotEqual(t, name2, name3)
+	assert.NotEqual(t, name1, name3)
+
+	// Each should contain their distinguishing parent directory
+	assert.Contains(t, name1, "org1")
+	assert.Contains(t, name2, "org2")
+	assert.Contains(t, name3, "org3")
+}
+
+func TestSanitizePackageName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"with-dash", "with_dash"},
+		{"with.dot", "with_dot"},
+		{"with/slash", "with_slash"},
+		{"MixedCase", "MixedCase"},
+		{"with-multiple-dashes", "with_multiple_dashes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := sanitizePackageName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateUniqueName(t *testing.T) {
+	tests := []struct {
+		name         string
+		packagePath  string
+		baseShort    string
+		allPaths     []string
+		shouldContain string
+	}{
+		{
+			name:         "http clients vs grpc clients",
+			packagePath:  "app/http/clients",
+			baseShort:    "clients",
+			allPaths:     []string{"app/http/clients", "app/grpc/clients"},
+			shouldContain: "http",
+		},
+		{
+			name:         "grpc clients vs http clients",
+			packagePath:  "app/grpc/clients",
+			baseShort:    "clients",
+			allPaths:     []string{"app/http/clients", "app/grpc/clients"},
+			shouldContain: "grpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateUniqueName(tt.packagePath, tt.baseShort, tt.allPaths)
+			assert.Contains(t, result, tt.shouldContain)
+		})
+	}
+}

--- a/service.go
+++ b/service.go
@@ -127,10 +127,10 @@ func (service *Service) astArguments() *ast.FieldList {
 		List: []*ast.Field{},
 	}
 
-	for arg, ty := range service.Arguments {
+	for _, arg := range service.Arguments.Names() {
 		funcParams.List = append(funcParams.List, &ast.Field{
 			Type: &ast.Ident{
-				Name: string(arg + " " + ty.String()),
+				Name: string(arg + " " + service.Arguments[arg].String()),
 			},
 		})
 	}

--- a/service.go
+++ b/service.go
@@ -25,43 +25,30 @@ type Service struct {
 	Type       Type
 }
 
-func (service *Service) ContainerFieldType(services Services) ast.Expr {
+func (service *Service) ContainerFieldType(services Services, importMap ImportMap) ast.Expr {
 	scope := service.Scope
 	if scope == ScopeNotSet {
 		scope = ScopeContainer
 	}
 
 	if scope == ScopeContainer && len(service.Arguments) == 0 {
-		return newIdent(service.InterfaceOrLocalEntityPointerType())
+		return newIdent(service.InterfaceOrLocalEntityPointerType(importMap))
 	}
 
-	return service.astFunctionPrototype(services)
+	return service.astFunctionPrototype(services, importMap)
 }
 
-func (service *Service) ContainerFieldTypeWithMap(services Services, importMap ImportMap) ast.Expr {
-	scope := service.Scope
-	if scope == ScopeNotSet {
-		scope = ScopeContainer
-	}
-
-	if scope == ScopeContainer && len(service.Arguments) == 0 {
-		return newIdent(service.InterfaceOrLocalEntityPointerTypeWithMap(importMap))
-	}
-
-	return service.astFunctionPrototypeWithMap(services, importMap)
-}
-
-func (service *Service) InterfaceOrLocalEntityType(services Services, recurse bool) string {
-	localEntityType := service.Type.LocalEntityType()
+func (service *Service) InterfaceOrLocalEntityType(services Services, recurse bool, importMap ImportMap) string {
+	localEntityType := service.Type.LocalEntityType(importMap)
 	if service.Interface != "" {
-		localEntityType = service.Interface.LocalEntityType()
+		localEntityType = service.Interface.LocalEntityType(importMap)
 	}
 
 	if len(service.Arguments) > 0 && recurse {
 		var args []string
 
 		for _, dep := range service.Returns.Dependencies() {
-			ty := services[dep].InterfaceOrLocalEntityType(services, false)
+			ty := services[dep].InterfaceOrLocalEntityType(services, false, importMap)
 			args = append(args, fmt.Sprintf("%s %s", dep, ty))
 		}
 
@@ -74,12 +61,12 @@ func (service *Service) InterfaceOrLocalEntityType(services Services, recurse bo
 	return localEntityType
 }
 
-func (service *Service) InterfaceOrLocalEntityPointerType() string {
+func (service *Service) InterfaceOrLocalEntityPointerType(importMap ImportMap) string {
 	if service.Interface != "" {
-		return service.Interface.LocalEntityType()
+		return service.Interface.LocalEntityType(importMap)
 	}
 
-	return service.Type.LocalEntityPointerType()
+	return service.Type.LocalEntityPointerType(importMap)
 }
 
 func (service *Service) Imports() map[string]string {
@@ -90,50 +77,16 @@ func (service *Service) Imports() map[string]string {
 	}
 
 	if service.Type.PackageName() != "" {
-		imports[service.Type.PackageName()] = service.Type.LocalPackageName()
+		imports[service.Type.PackageName()] = service.Type.LocalPackageName(nil)
 	}
 
 	if service.Interface.PackageName() != "" {
-		imports[service.Interface.PackageName()] = service.Interface.LocalPackageName()
+		imports[service.Interface.PackageName()] = service.Interface.LocalPackageName(nil)
 	}
 
 	return imports
 }
 
-// InterfaceOrLocalEntityTypeWithMap returns the entity type using a resolved import map
-func (service *Service) InterfaceOrLocalEntityTypeWithMap(services Services, recurse bool, importMap ImportMap) string {
-	ty := service.Type
-	if service.Interface != "" {
-		ty = service.Interface
-	}
-
-	localEntityType := ty.LocalEntityTypeWithMap(importMap)
-
-	if len(service.Arguments) > 0 && recurse {
-		var args []string
-
-		for _, dep := range service.Returns.Dependencies() {
-			depType := services[dep].InterfaceOrLocalEntityTypeWithMap(services, false, importMap)
-			args = append(args, fmt.Sprintf("%s %s", dep, depType))
-		}
-
-		args = append(args, service.Arguments.GoArguments()...)
-
-		return fmt.Sprintf("func(%v) %s", strings.Join(args, ", "),
-			localEntityType)
-	}
-
-	return localEntityType
-}
-
-// InterfaceOrLocalEntityPointerTypeWithMap returns the pointer type using a resolved import map
-func (service *Service) InterfaceOrLocalEntityPointerTypeWithMap(importMap ImportMap) string {
-	if service.Interface != "" {
-		return service.Interface.LocalEntityTypeWithMap(importMap)
-	}
-
-	return service.Type.LocalEntityPointerTypeWithMap(importMap)
-}
 
 func (service *Service) SortedProperties() (sortedProperties []*Property) {
 	var propertyNames []string
@@ -186,22 +139,22 @@ func (service *Service) astArguments() *ast.FieldList {
 	return funcParams
 }
 
-func (service *Service) astDependencyArguments(services Services) *ast.FieldList {
+func (service *Service) astDependencyArguments(services Services, importMap ImportMap) *ast.FieldList {
 	funcParams := &ast.FieldList{
 		List: []*ast.Field{},
 	}
 
 	for _, dep := range service.Returns.DependencyNames() {
 		funcParams.List = append(funcParams.List, &ast.Field{
-			Type: newIdent(dep + " " + services[dep].InterfaceOrLocalEntityType(services, false)),
+			Type: newIdent(dep + " " + services[dep].InterfaceOrLocalEntityType(services, false, importMap)),
 		})
 	}
 
 	return funcParams
 }
 
-func (service *Service) astAllArguments(services Services) *ast.FieldList {
-	deps := service.astDependencyArguments(services)
+func (service *Service) astAllArguments(services Services, importMap ImportMap) *ast.FieldList {
+	deps := service.astDependencyArguments(services, importMap)
 	args := service.astArguments()
 
 	return &ast.FieldList{
@@ -209,8 +162,8 @@ func (service *Service) astAllArguments(services Services) *ast.FieldList {
 	}
 }
 
-func (service *Service) astFunctionPrototype(services Services) *ast.FuncType {
-	ty := Type(service.InterfaceOrLocalEntityType(services, true))
+func (service *Service) astFunctionPrototype(services Services, importMap ImportMap) *ast.FuncType {
+	ty := Type(service.InterfaceOrLocalEntityType(services, true, importMap))
 	if ty.IsFunction() {
 		args, returns := ty.parseFunctionType()
 
@@ -221,48 +174,8 @@ func (service *Service) astFunctionPrototype(services Services) *ast.FuncType {
 	}
 
 	return &ast.FuncType{
-		Params:  service.astAllArguments(services),
+		Params:  service.astAllArguments(services, importMap),
 		Results: newFieldList(string(ty)),
-	}
-}
-
-func (service *Service) astFunctionPrototypeWithMap(services Services, importMap ImportMap) *ast.FuncType {
-	ty := Type(service.InterfaceOrLocalEntityTypeWithMap(services, true, importMap))
-	if ty.IsFunction() {
-		args, returns := ty.parseFunctionType()
-
-		return &ast.FuncType{
-			Params:  newFieldList(args),
-			Results: newFieldList(returns...),
-		}
-	}
-
-	return &ast.FuncType{
-		Params:  service.astAllArgumentsWithMap(services, importMap),
-		Results: newFieldList(string(ty)),
-	}
-}
-
-func (service *Service) astDependencyArgumentsWithMap(services Services, importMap ImportMap) *ast.FieldList {
-	funcParams := &ast.FieldList{
-		List: []*ast.Field{},
-	}
-
-	for _, dep := range service.Returns.DependencyNames() {
-		funcParams.List = append(funcParams.List, &ast.Field{
-			Type: newIdent(dep + " " + services[dep].InterfaceOrLocalEntityTypeWithMap(services, false, importMap)),
-		})
-	}
-
-	return funcParams
-}
-
-func (service *Service) astAllArgumentsWithMap(services Services, importMap ImportMap) *ast.FieldList {
-	deps := service.astDependencyArgumentsWithMap(services, importMap)
-	args := service.astArguments()
-
-	return &ast.FieldList{
-		List: append(deps.List, args.List...),
 	}
 }
 
@@ -294,7 +207,7 @@ func (service *Service) astFunctionBody(file *File, services Services, name, ser
 				Lhs: []ast.Expr{newIdent(serviceTempVariable)},
 				Rhs: []ast.Expr{
 					&ast.CompositeLit{
-						Type: newIdent(service.Type.CreateLocalEntityTypeWithMap(file.importMap)),
+						Type: newIdent(service.Type.CreateLocalEntityType(file.importMap)),
 					},
 				},
 			},

--- a/service.go
+++ b/service.go
@@ -38,6 +38,19 @@ func (service *Service) ContainerFieldType(services Services) ast.Expr {
 	return service.astFunctionPrototype(services)
 }
 
+func (service *Service) ContainerFieldTypeWithMap(services Services, importMap ImportMap) ast.Expr {
+	scope := service.Scope
+	if scope == ScopeNotSet {
+		scope = ScopeContainer
+	}
+
+	if scope == ScopeContainer && len(service.Arguments) == 0 {
+		return newIdent(service.InterfaceOrLocalEntityPointerTypeWithMap(importMap))
+	}
+
+	return service.astFunctionPrototypeWithMap(services, importMap)
+}
+
 func (service *Service) InterfaceOrLocalEntityType(services Services, recurse bool) string {
 	localEntityType := service.Type.LocalEntityType()
 	if service.Interface != "" {
@@ -85,6 +98,41 @@ func (service *Service) Imports() map[string]string {
 	}
 
 	return imports
+}
+
+// InterfaceOrLocalEntityTypeWithMap returns the entity type using a resolved import map
+func (service *Service) InterfaceOrLocalEntityTypeWithMap(services Services, recurse bool, importMap ImportMap) string {
+	ty := service.Type
+	if service.Interface != "" {
+		ty = service.Interface
+	}
+
+	localEntityType := ty.LocalEntityTypeWithMap(importMap)
+
+	if len(service.Arguments) > 0 && recurse {
+		var args []string
+
+		for _, dep := range service.Returns.Dependencies() {
+			depType := services[dep].InterfaceOrLocalEntityTypeWithMap(services, false, importMap)
+			args = append(args, fmt.Sprintf("%s %s", dep, depType))
+		}
+
+		args = append(args, service.Arguments.GoArguments()...)
+
+		return fmt.Sprintf("func(%v) %s", strings.Join(args, ", "),
+			localEntityType)
+	}
+
+	return localEntityType
+}
+
+// InterfaceOrLocalEntityPointerTypeWithMap returns the pointer type using a resolved import map
+func (service *Service) InterfaceOrLocalEntityPointerTypeWithMap(importMap ImportMap) string {
+	if service.Interface != "" {
+		return service.Interface.LocalEntityTypeWithMap(importMap)
+	}
+
+	return service.Type.LocalEntityPointerTypeWithMap(importMap)
 }
 
 func (service *Service) SortedProperties() (sortedProperties []*Property) {
@@ -178,6 +226,46 @@ func (service *Service) astFunctionPrototype(services Services) *ast.FuncType {
 	}
 }
 
+func (service *Service) astFunctionPrototypeWithMap(services Services, importMap ImportMap) *ast.FuncType {
+	ty := Type(service.InterfaceOrLocalEntityTypeWithMap(services, true, importMap))
+	if ty.IsFunction() {
+		args, returns := ty.parseFunctionType()
+
+		return &ast.FuncType{
+			Params:  newFieldList(args),
+			Results: newFieldList(returns...),
+		}
+	}
+
+	return &ast.FuncType{
+		Params:  service.astAllArgumentsWithMap(services, importMap),
+		Results: newFieldList(string(ty)),
+	}
+}
+
+func (service *Service) astDependencyArgumentsWithMap(services Services, importMap ImportMap) *ast.FieldList {
+	funcParams := &ast.FieldList{
+		List: []*ast.Field{},
+	}
+
+	for _, dep := range service.Returns.DependencyNames() {
+		funcParams.List = append(funcParams.List, &ast.Field{
+			Type: newIdent(dep + " " + services[dep].InterfaceOrLocalEntityTypeWithMap(services, false, importMap)),
+		})
+	}
+
+	return funcParams
+}
+
+func (service *Service) astAllArgumentsWithMap(services Services, importMap ImportMap) *ast.FieldList {
+	deps := service.astDependencyArgumentsWithMap(services, importMap)
+	args := service.astArguments()
+
+	return &ast.FieldList{
+		List: append(deps.List, args.List...),
+	}
+}
+
 func (service *Service) astFunctionBody(file *File, services Services, name, serviceName string) *ast.BlockStmt {
 	if name != "" && service.Scope == ScopePrototype {
 		var arguments []string
@@ -206,7 +294,7 @@ func (service *Service) astFunctionBody(file *File, services Services, name, ser
 				Lhs: []ast.Expr{newIdent(serviceTempVariable)},
 				Rhs: []ast.Expr{
 					&ast.CompositeLit{
-						Type: newIdent(service.Type.CreateLocalEntityType()),
+						Type: newIdent(service.Type.CreateLocalEntityTypeWithMap(file.importMap)),
 					},
 				},
 			},
@@ -218,12 +306,18 @@ func (service *Service) astFunctionBody(file *File, services Services, name, ser
 			lhs = append(lhs, newIdent("err"))
 		}
 
+		// Perform substitutions with context awareness for package prefixes
+		substitutedReturns := service.Returns.performSubstitutions(file, services, name == "")
+		if file.importMap != nil {
+			substitutedReturns = service.Returns.replacePackagePrefixesWithContext(substitutedReturns, service.Type, file.importMap)
+		}
+
 		instantiation = []ast.Stmt{
 			&ast.AssignStmt{
 				Tok: token.DEFINE,
 				Lhs: lhs,
 				Rhs: []ast.Expr{
-					newIdent(service.Returns.performSubstitutions(file, services, name == "")),
+					newIdent(substitutedReturns),
 				},
 			},
 		}
@@ -244,10 +338,15 @@ func (service *Service) astFunctionBody(file *File, services Services, name, ser
 
 	// Properties
 	for _, property := range service.SortedProperties() {
+		substitutedValue := property.Value.performSubstitutions(file, services, name == "")
+		if file.importMap != nil {
+			substitutedValue = property.Value.replacePackagePrefixesWithContext(substitutedValue, service.Type, file.importMap)
+		}
+
 		instantiation = append(instantiation, &ast.AssignStmt{
 			Tok: token.ASSIGN,
 			Lhs: []ast.Expr{&ast.Ident{Name: serviceTempVariable + "." + property.Name}},
-			Rhs: []ast.Expr{&ast.Ident{Name: property.Value.performSubstitutions(file, services, name == "")}},
+			Rhs: []ast.Expr{&ast.Ident{Name: substitutedValue}},
 		})
 	}
 

--- a/service_test.go
+++ b/service_test.go
@@ -263,7 +263,7 @@ func TestService_ContainerFieldType(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			actual := test.services["A"].ContainerFieldType(test.services)
+			actual := test.services["A"].ContainerFieldType(test.services, nil)
 			assert.Equal(t, test.containerFieldType, actual)
 		})
 	}

--- a/services.go
+++ b/services.go
@@ -33,7 +33,7 @@ func (services Services) ServicesWithScope(scope string) Services {
 }
 
 // astContainer creates the Container struct.
-func (services Services) astContainerStruct() *ast.GenDecl {
+func (services Services) astContainerStruct(importMap ImportMap) *ast.GenDecl {
 	var containerFields []*ast.Field
 	for _, serviceName := range services.ServiceNames() {
 		service := services[serviceName]
@@ -42,35 +42,7 @@ func (services Services) astContainerStruct() *ast.GenDecl {
 			Names: []*ast.Ident{
 				{Name: serviceName},
 			},
-			Type: service.ContainerFieldType(services),
-		})
-	}
-
-	return &ast.GenDecl{
-		Tok: token.TYPE,
-		Specs: []ast.Spec{
-			&ast.TypeSpec{
-				Name: newIdent("Container"),
-				Type: &ast.StructType{
-					Fields: &ast.FieldList{
-						List: containerFields,
-					},
-				},
-			},
-		},
-	}
-}
-
-func (services Services) astContainerStructWithMap(importMap ImportMap) *ast.GenDecl {
-	var containerFields []*ast.Field
-	for _, serviceName := range services.ServiceNames() {
-		service := services[serviceName]
-
-		containerFields = append(containerFields, &ast.Field{
-			Names: []*ast.Ident{
-				{Name: serviceName},
-			},
-			Type: service.ContainerFieldTypeWithMap(services, importMap),
+			Type: service.ContainerFieldType(services, importMap),
 		})
 	}
 

--- a/services.go
+++ b/services.go
@@ -61,6 +61,34 @@ func (services Services) astContainerStruct() *ast.GenDecl {
 	}
 }
 
+func (services Services) astContainerStructWithMap(importMap ImportMap) *ast.GenDecl {
+	var containerFields []*ast.Field
+	for _, serviceName := range services.ServiceNames() {
+		service := services[serviceName]
+
+		containerFields = append(containerFields, &ast.Field{
+			Names: []*ast.Ident{
+				{Name: serviceName},
+			},
+			Type: service.ContainerFieldTypeWithMap(services, importMap),
+		})
+	}
+
+	return &ast.GenDecl{
+		Tok: token.TYPE,
+		Specs: []ast.Spec{
+			&ast.TypeSpec{
+				Name: newIdent("Container"),
+				Type: &ast.StructType{
+					Fields: &ast.FieldList{
+						List: containerFields,
+					},
+				},
+			},
+		},
+	}
+}
+
 func (services Services) astDefaultContainer() *ast.GenDecl {
 	return &ast.GenDecl{
 		Tok: token.VAR,

--- a/type.go
+++ b/type.go
@@ -53,21 +53,7 @@ func (ty Type) UnversionedPackageName() string {
 	return strings.Join(packageName, "/")
 }
 
-func (ty Type) LocalPackageName() string {
-	if ty.IsFunction() {
-		return ""
-	}
-
-	pkgNameParts := strings.Split(ty.UnversionedPackageName(), "/")
-	lastPart := pkgNameParts[len(pkgNameParts)-1]
-	if lastPart == "" {
-		lastPart = ty.PackageName()
-	}
-	return strings.Replace(lastPart, "-", "_", -1)
-}
-
-// LocalPackageNameWithMap returns the package name using a resolved import map
-func (ty Type) LocalPackageNameWithMap(importMap ImportMap) string {
+func (ty Type) LocalPackageName(importMap ImportMap) string {
 	if ty.IsFunction() {
 		return ""
 	}
@@ -77,13 +63,18 @@ func (ty Type) LocalPackageNameWithMap(importMap ImportMap) string {
 		return ""
 	}
 
-	// Check if we have a resolved name for this package
-	if resolvedName, ok := importMap[packageName]; ok {
-		return resolvedName
+	if importMap != nil {
+		if resolvedName, ok := importMap[packageName]; ok {
+			return resolvedName
+		}
 	}
 
-	// Fallback to default behavior
-	return ty.LocalPackageName()
+	pkgNameParts := strings.Split(ty.UnversionedPackageName(), "/")
+	lastPart := pkgNameParts[len(pkgNameParts)-1]
+	if lastPart == "" {
+		lastPart = packageName
+	}
+	return strings.Replace(lastPart, "-", "_", -1)
 }
 
 func (ty Type) EntityName() string {
@@ -96,33 +87,22 @@ func (ty Type) EntityName() string {
 	return strings.TrimLeft(parts[len(parts)-1], "*")
 }
 
-func (ty Type) LocalEntityName() string {
+func (ty Type) LocalEntityName(importMap ImportMap) string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
-	name := ty.LocalPackageName() + "." + ty.EntityName()
+	name := ty.LocalPackageName(importMap) + "." + ty.EntityName()
 
 	return strings.TrimLeft(name, ".")
 }
 
-// LocalEntityNameWithMap returns the entity name using a resolved import map
-func (ty Type) LocalEntityNameWithMap(importMap ImportMap) string {
+func (ty Type) LocalEntityType(importMap ImportMap) string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
-	name := ty.LocalPackageNameWithMap(importMap) + "." + ty.EntityName()
-
-	return strings.TrimLeft(name, ".")
-}
-
-func (ty Type) LocalEntityType() string {
-	if ty.IsFunction() {
-		return ty.String()
-	}
-
-	name := ty.LocalEntityName()
+	name := ty.LocalEntityName(importMap)
 	if ty.IsPointer() {
 		name = "*" + name
 	}
@@ -130,26 +110,12 @@ func (ty Type) LocalEntityType() string {
 	return name
 }
 
-// LocalEntityTypeWithMap returns the entity type using a resolved import map
-func (ty Type) LocalEntityTypeWithMap(importMap ImportMap) string {
+func (ty Type) CreateLocalEntityType(importMap ImportMap) string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
-	name := ty.LocalEntityNameWithMap(importMap)
-	if ty.IsPointer() {
-		name = "*" + name
-	}
-
-	return name
-}
-
-func (ty Type) CreateLocalEntityType() string {
-	if ty.IsFunction() {
-		return ty.String()
-	}
-
-	name := ty.LocalEntityName()
+	name := ty.LocalEntityName(importMap)
 	if ty.IsPointer() {
 		name = "&" + name
 	}
@@ -157,40 +123,12 @@ func (ty Type) CreateLocalEntityType() string {
 	return name
 }
 
-// CreateLocalEntityTypeWithMap returns the create syntax using a resolved import map
-func (ty Type) CreateLocalEntityTypeWithMap(importMap ImportMap) string {
+func (ty Type) LocalEntityPointerType(importMap ImportMap) string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
-	name := ty.LocalEntityNameWithMap(importMap)
-	if ty.IsPointer() {
-		name = "&" + name
-	}
-
-	return name
-}
-
-func (ty Type) LocalEntityPointerType() string {
-	if ty.IsFunction() {
-		return ty.String()
-	}
-
-	name := ty.LocalEntityName()
-	if !strings.HasPrefix(name, "*") {
-		name = "*" + name
-	}
-
-	return name
-}
-
-// LocalEntityPointerTypeWithMap returns the pointer type using a resolved import map
-func (ty Type) LocalEntityPointerTypeWithMap(importMap ImportMap) string {
-	if ty.IsFunction() {
-		return ty.String()
-	}
-
-	name := ty.LocalEntityNameWithMap(importMap)
+	name := ty.LocalEntityName(importMap)
 	if !strings.HasPrefix(name, "*") {
 		name = "*" + name
 	}

--- a/type.go
+++ b/type.go
@@ -66,6 +66,26 @@ func (ty Type) LocalPackageName() string {
 	return strings.Replace(lastPart, "-", "_", -1)
 }
 
+// LocalPackageNameWithMap returns the package name using a resolved import map
+func (ty Type) LocalPackageNameWithMap(importMap ImportMap) string {
+	if ty.IsFunction() {
+		return ""
+	}
+
+	packageName := ty.PackageName()
+	if packageName == "" {
+		return ""
+	}
+
+	// Check if we have a resolved name for this package
+	if resolvedName, ok := importMap[packageName]; ok {
+		return resolvedName
+	}
+
+	// Fallback to default behavior
+	return ty.LocalPackageName()
+}
+
 func (ty Type) EntityName() string {
 	if ty.IsFunction() {
 		return ty.String()
@@ -86,12 +106,37 @@ func (ty Type) LocalEntityName() string {
 	return strings.TrimLeft(name, ".")
 }
 
+// LocalEntityNameWithMap returns the entity name using a resolved import map
+func (ty Type) LocalEntityNameWithMap(importMap ImportMap) string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
+	name := ty.LocalPackageNameWithMap(importMap) + "." + ty.EntityName()
+
+	return strings.TrimLeft(name, ".")
+}
+
 func (ty Type) LocalEntityType() string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
 	name := ty.LocalEntityName()
+	if ty.IsPointer() {
+		name = "*" + name
+	}
+
+	return name
+}
+
+// LocalEntityTypeWithMap returns the entity type using a resolved import map
+func (ty Type) LocalEntityTypeWithMap(importMap ImportMap) string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
+	name := ty.LocalEntityNameWithMap(importMap)
 	if ty.IsPointer() {
 		name = "*" + name
 	}
@@ -112,12 +157,40 @@ func (ty Type) CreateLocalEntityType() string {
 	return name
 }
 
+// CreateLocalEntityTypeWithMap returns the create syntax using a resolved import map
+func (ty Type) CreateLocalEntityTypeWithMap(importMap ImportMap) string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
+	name := ty.LocalEntityNameWithMap(importMap)
+	if ty.IsPointer() {
+		name = "&" + name
+	}
+
+	return name
+}
+
 func (ty Type) LocalEntityPointerType() string {
 	if ty.IsFunction() {
 		return ty.String()
 	}
 
 	name := ty.LocalEntityName()
+	if !strings.HasPrefix(name, "*") {
+		name = "*" + name
+	}
+
+	return name
+}
+
+// LocalEntityPointerTypeWithMap returns the pointer type using a resolved import map
+func (ty Type) LocalEntityPointerTypeWithMap(importMap ImportMap) string {
+	if ty.IsFunction() {
+		return ty.String()
+	}
+
+	name := ty.LocalEntityNameWithMap(importMap)
 	if !strings.HasPrefix(name, "*") {
 		name = "*" + name
 	}

--- a/type_test.go
+++ b/type_test.go
@@ -164,7 +164,7 @@ func TestType_PackageName(t *testing.T) {
 func TestType_LocalPackageName(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, test.LocalPackageName, ty.LocalPackageName())
+			assert.Equal(t, test.LocalPackageName, ty.LocalPackageName(nil))
 		})
 	}
 }
@@ -180,7 +180,7 @@ func TestType_EntityName(t *testing.T) {
 func TestType_LocalEntityName(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, test.LocalEntityName, ty.LocalEntityName())
+			assert.Equal(t, test.LocalEntityName, ty.LocalEntityName(nil))
 		})
 	}
 }
@@ -188,7 +188,7 @@ func TestType_LocalEntityName(t *testing.T) {
 func TestType_LocalEntityType(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, test.LocalEntityType, ty.LocalEntityType())
+			assert.Equal(t, test.LocalEntityType, ty.LocalEntityType(nil))
 		})
 	}
 }
@@ -196,7 +196,7 @@ func TestType_LocalEntityType(t *testing.T) {
 func TestType_CreateLocalEntityType(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, test.CreateLocalEntityType, ty.CreateLocalEntityType())
+			assert.Equal(t, test.CreateLocalEntityType, ty.CreateLocalEntityType(nil))
 		})
 	}
 }
@@ -204,7 +204,7 @@ func TestType_CreateLocalEntityType(t *testing.T) {
 func TestType_LocalEntityPointerType(t *testing.T) {
 	for ty, test := range typeTests {
 		t.Run(string(ty), func(t *testing.T) {
-			assert.Equal(t, test.LocalEntityPointerType, ty.LocalEntityPointerType())
+			assert.Equal(t, test.LocalEntityPointerType, ty.LocalEntityPointerType(nil))
 		})
 	}
 }


### PR DESCRIPTION
Resolve issue #21 

Automatically detect conflicts between different packages sharing the same name (for example: "app/http/clients" vs "app/grpc/clients") and generate unique aliases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/dingo/22)
<!-- Reviewable:end -->
